### PR TITLE
 IFS-5514: fixed NVDA bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - IFS-4927: Der Hauptinhalt ist zentriert, Abstände werden über Container-Gaps bzw. Spacing-Tokens gesteuert und doppelte Margins zwischen Komponenten wurden entfernt.
 - IFS-4931: Die Komponente `form-wrapper` und der Service zur Übersetzung von Beschriftungen in der _isy-angular-widgets_ Bibliothek wurden überarbeitet
 ## Fixes
+- IFS-5514: In der PrimeNG-Formular-Demo wird die sichtbare Validierungsfehlermeldung des Eingabefeldes mit Hilfetext per `aria-describedby` referenziert, damit Screenreader die Fehlermeldung beim erneuten Fokussieren vorlesen.
 - IFS-5026: `isy-incomplete-date` setzt Pflichtfelder nun korrekt mit `required` und `aria-required`
 - IFS-549: Performanzproblem bei mehrfacher Einbindung der `InputCharComponent` wurde behoben
 - IFS-4947: Farbe für Disabled-Buttons wurde angepasst

--- a/projects/isy-angular-widgets-demo/src/app/feature/primeng-widgets/components/primeng-form/primeng-form.component.html
+++ b/projects/isy-angular-widgets-demo/src/app/feature/primeng-widgets/components/primeng-form/primeng-form.component.html
@@ -16,12 +16,16 @@
           [placeholder]="'isyAngularWidgetsDemo.placeholders.inputTextWithHelp' | translate"
           [invalid]="inputTextModel.invalid && inputTextModel.touched"
           minlength="3"
-          aria-describedby="input-text-help"
+          [attr.aria-describedby]="
+            inputTextModel.invalid && inputTextModel.touched
+              ? 'input-text-help input-text-validation-error'
+              : 'input-text-help'
+          "
           #inputTextModel="ngModel"
         />
         <small id="input-text-help">{{ 'isyAngularWidgetsDemo.messages.inputTextHelp' | translate }}</small>
         @if (inputTextModel.invalid && inputTextModel.touched) {
-          <p-message severity="error" variant="simple">
+          <p-message id="input-text-validation-error" severity="error" variant="simple">
             @if (inputTextModel.errors?.['minlength']) {
               {{
                 'isyAngularWidgetsDemo.messages.minLengthError'

--- a/projects/isy-angular-widgets-demo/src/app/feature/primeng-widgets/components/primeng-form/primeng-form.component.spec.ts
+++ b/projects/isy-angular-widgets-demo/src/app/feature/primeng-widgets/components/primeng-form/primeng-form.component.spec.ts
@@ -175,6 +175,13 @@ describe('Unit Tests: PrimengFormComponent', () => {
     expect(spectator.query('p-message')).toBeFalsy();
   });
 
+  it('should describe InputText validation field with help text before an error is shown', () => {
+    const input = spectator.query<HTMLInputElement>('#input-text-validation');
+
+    expect(input).toHaveAttribute('aria-describedby', 'input-text-help');
+    expect(spectator.query('#input-text-validation-error')).toBeFalsy();
+  });
+
   it('should show required validation error after InputText field is touched', () => {
     const input = spectator.query<HTMLInputElement>('#input-text-validation');
 
@@ -184,6 +191,17 @@ describe('Unit Tests: PrimengFormComponent', () => {
     spectator.detectChanges();
 
     expect(spectator.query('p-message')).toBeTruthy();
+  });
+
+  it('should describe InputText validation field with help text and error when an error is shown', () => {
+    const input = spectator.query<HTMLInputElement>('#input-text-validation');
+
+    spectator.typeInElement('ab', input as HTMLInputElement);
+    spectator.dispatchFakeEvent(input as HTMLInputElement, 'blur');
+    spectator.detectChanges();
+
+    expect(spectator.query('#input-text-validation-error')).toBeTruthy();
+    expect(input).toHaveAttribute('aria-describedby', 'input-text-help input-text-validation-error');
   });
 
   it('should apply minlength validation to InputText and show error for too-short input', () => {


### PR DESCRIPTION
Die im Ticket verlinkte reproduktion betrifft die PrimeNG-Form-Demo. Das betroffene Eingabefeld verwendet keinen isy-form-wrapper, daher wurde die fehlende ARIA-Verknüpfung direkt an dieser Demo-Stelle ergänzt. Die isy-form-wrapper-Komponente wurde zusätzlich anhand bestehender Demo-Stellen geprüft. Bei nativen Feldern mit isyformWrapperfield setzt sie die Fehlerreferenzen bereits wie erwartet.