### PR TITLE
fix(ci): harmonize CI/publish quality checks and support prerelease tags

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -5,7 +5,7 @@ on:
     types: [ opened, synchronize, reopened ]
   push:
     tags:
-      - '^\\d+\\.\\d+\\.\\d+$'
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   DocsBuild:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,16 +38,27 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
+      - name: Validate CHANGELOG on release branches
+        if: startsWith(github.ref, 'refs/heads/release/')
+        run: |
+          VERSION="${GITHUB_REF_NAME#release/}"
+          FIRST_CHANGELOG_LINE=$(head -n 1 CHANGELOG.md)
+          if [[ "$FIRST_CHANGELOG_LINE" =~ ^\#[[:space:]]${VERSION//./\\.}.* ]]; then
+            echo "First changelog entry describes current release version $VERSION"
+          else
+            echo "First changelog entry does not describe current release version $VERSION."
+            exit 1
+          fi
       - name: Bootstrap install (build local package)
         run: |
-          npm ci --ignore-scripts --legacy-peer-deps
+          npm ci --ignore-scripts
           git checkout package.json
       - name: Build local package
         run: |
           npm run build:widgets_lib
           npm run pack:widgets_lib
       - name: Install dependencies
-        run: npm ci --ignore-scripts --legacy-peer-deps
+        run: npm ci --ignore-scripts
       - name: Check code formatting
         run: |
           npm run prettier:check
@@ -57,6 +68,13 @@ jobs:
         run: npm run lint:demo
       - name: Run tests
         run: npm test
+      - name: Build demo application
+        run: npm run build:widgets_demo
+      - name: Build documentation (Compodoc)
+        run: npm run compodoc:build
+      - name: Generate SBOM (smoke test)
+        continue-on-error: true
+        run: npx @cyclonedx/cyclonedx-npm --output-file /tmp/sbom-smoke.json
       - name: Cache SonarCloud
         uses: actions/cache@v4
         with:
@@ -76,8 +94,6 @@ jobs:
             -Dsonar.test.inclusions=**/*.spec.ts
             -Dsonar.javascript.lcov.reportPaths=coverage/**/lcov.info
             -Dsonar.coverage.exclusions=**/main.ts,**/polyfills.ts,**/environment*.ts,**/environments/**,**/*.module.ts,**/test.ts,**/karma.conf.js,**/eslint.config.js,**/schematics/**,**/test/**,tools/generate-browser-support.mjs
-      - name: Build project
-        run: npm run build --if-present
 
   build_and_deploy_demo_and_docs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,7 +6,8 @@ name: Node.js Package
 on:
   push:
     tags:
-      - '\d+.\d+.\d+'
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
 
 env:
   RELEASE_VERSION: ${{ github.ref_name }}
@@ -14,6 +15,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      is_prerelease: ${{ steps.classify.outputs.is_prerelease }}
+      dist_tag: ${{ steps.classify.outputs.dist_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,17 +33,38 @@ jobs:
         with:
           node-version: 24
           cache: "npm"
+      - name: Classify release
+        id: classify
+        run: |
+          if [[ "$RELEASE_VERSION" == *-* ]]; then
+            PRE="${RELEASE_VERSION#*-}"
+            TAG="${PRE%%.*}"
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "dist_tag=${TAG:-next}" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
       - name: Validate latest changelog entry
         run: |
+          BASE_VERSION="${RELEASE_VERSION%%-*}"
           FIRST_CHANGELOG_LINE=$(head -n 1 CHANGELOG.md)
-          if [[ "$FIRST_CHANGELOG_LINE" =~ ^\#[[:space:]]${RELEASE_VERSION//./\\.}.* ]]; then
-            echo "First changelog entry describes current version $RELEASE_VERSION"
+          if [[ "$FIRST_CHANGELOG_LINE" =~ ^\#[[:space:]]${BASE_VERSION//./\\.}.* ]]; then
+            echo "First changelog entry describes current version $BASE_VERSION"
           else
-            echo "First changelog entry does not describe current version $RELEASE_VERSION."
+            echo "First changelog entry does not describe current version $BASE_VERSION."
             exit 1
           fi
+      - name: Bootstrap install (build local package)
+        run: |
+          npm ci --ignore-scripts
+          git checkout package.json
+      - name: Build local package
+        run: |
+          npm run build:widgets_lib
+          npm run pack:widgets_lib
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Check code formatting and linting
         run: |
           npm run prettier:check
@@ -85,6 +110,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 24
@@ -93,11 +120,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Build
+          path: dist/isy-angular-widgets/
       - name: Download SBOM
         uses: actions/download-artifact@v4
         with:
           name: SBOM
       - name: Bump version in package.json
+        working-directory: dist/isy-angular-widgets
         run: |
           # jq can't replace file contents directly therefore a tmp file is needed
           tmp_file=$(mktemp)
@@ -106,6 +135,7 @@ jobs:
             && jq --arg version "$RELEASE_VERSION" '.version=$version' "$tmp_file" >package.json \
             && rm -f "$tmp_file"
       - name: Publish to npm
-        run: npm publish --access public
+        working-directory: dist/isy-angular-widgets
+        run: npm publish --access public --tag "${{ needs.build.outputs.dist_tag }}"
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
- Move demo build and Compodoc build into main CI job so they run on every PR/push instead of only on develop deploy
- Add non-blocking SBOM smoke test to CI
- Align publish install strategy with CI (bootstrap + self-consuming lib)
- Move legacy-peer-deps from build scripts into .npmrc
- Add CHANGELOG prevalidation on release/* branches
- Fix missing actions/checkout in publish-npm job
- Fix docs_build.yml tag trigger (glob instead of regex)
- Support prerelease tags like 2.0.1-next.1: extend tag trigger, classify release, publish prereleases with --tag next (or beta/rc)
- Validate CHANGELOG against base version for prereleases
- Drop redundant final full build in CI (already covered by explicit lib+demo)